### PR TITLE
showing default domain & port in basic usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ And then create an app.js that looks like this.
 define(['arango'],function(arango){
       var e = document.getElementsByTagName("div")[0];
 
-      var db = new arango.Connection;
+	  var db = new arango.Connection("http://localhost:8529");
       
       /* list all collections */
       db.collection.list().then(function(res){


### PR DESCRIPTION
Hi Anders,

this week we had a support case in the ArangoDB group where someone tried "desperately" to get the client up and running - obviously very new to nodejs (like me ;-)). The basic example given in the documentation did work for me when I included the default domain & port. To make it a bit easier for other n00bs I suggest to add this information to the readme.
Feel free to discard this PR. :-)

Dorthe
