### PR TITLE
updated use of reserved keywords like "in", "for" and "return" as functi...

### DIFF
--- a/lib/api/query.js
+++ b/lib/api/query.js
@@ -5,7 +5,7 @@ require('./cursor');
 
 function Aql() {
 
-    var keywords = ['for', 'in', 'filter', 'from', 'include', 'collect', 'into', 'sort', 'limit', 'let', 'return'],
+    var keywords = ['For', 'In', 'filter', 'from', 'include', 'collect', 'into', 'sort', 'limit', 'let', 'Return'],
         aql = this;
 
     keywords.forEach(function(key) {
@@ -62,7 +62,7 @@ function Aql() {
             if (typeof value === 'object') {
                 var nested = structToString(value);
 
-                if (q === 'in') str = keyword + ' ( ' + nested + ' )';
+                if (q === 'In') str = keyword + ' ( ' + nested + ' )';
                 else str = keyword + ' ' + nested;
 
             } else str = keyword + ' ' + value;


### PR DESCRIPTION
...on names

Using reserved keywords like "for", "in" and "return" as function names created problems in IDE like Eclipse. So they are updated to "For", "In" and "Return" respectively.
