### PR TITLE
set agent for node > 0.10

### DIFF
--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -45,15 +45,12 @@ if (!BROWSER) {
 	options.headers['content-length'] = data ? Buffer.byteLength(data) : 0;
 	options.headers['connection']     = 'keep-alive';
 	
-	if (!agents[proto]) {
-	    if(minVersion > 10) {
-	        agents[proto] = new (require(proto)).Agent({keepAlive:true, keepAliveMsecs:300 * 1000});
-	    } else {
-	        agents[proto] = new (require(proto)).Agent({maxSockets:1});
-	    }
+	if (!agents[proto] && minVersion > 10) {
+	    agents[proto] = new (require(proto)).Agent({keepAlive:true, keepAliveMsecs:300 * 1000});
 	}
-
-	options.agent = agents[proto];
+	if(agents[proto] && minVersion > 10) {
+	    options.agent = agents[proto];
+	}
 
 	req(options,function (res) {
 	    var buf = [];


### PR DESCRIPTION
Set an Agent for node > 0.10 because otherwise the socket connection to the db server ist closed instantly when there are no more requests.

Without:

```
watch -n 1 "ss -tan |grep 8529|wc -l"
Every 1.0s: ss -tan |grep 8529                                                                                                                             Tue Nov 18 21:52:10 2014

LISTEN     0      10                        *:8529                     *:*
TIME-WAIT  0      0                 127.0.0.1:34983            127.0.0.1:8529
TIME-WAIT  0      0                 127.0.0.1:33983            127.0.0.1:8529
TIME-WAIT  0      0                 127.0.0.1:33750            127.0.0.1:8529
TIME-WAIT  0      0                 127.0.0.1:35794            127.0.0.1:8529
TIME-WAIT  0      0                 127.0.0.1:34325            127.0.0.1:8529
TIME-WAIT  0      0                 127.0.0.1:60321            127.0.0.1:8529
TIME-WAIT  0      0                 127.0.0.1:35208            127.0.0.1:8529
TIME-WAIT  0      0                 127.0.0.1:32815            127.0.0.1:8529
TIME-WAIT  0      0                 127.0.0.1:35449            127.0.0.1:8529
TIME-WAIT  0      0                 127.0.0.1:33594            127.0.0.1:8529
TIME-WAIT  0      0                 127.0.0.1:33167            127.0.0.1:8529
TIME-WAIT  0      0                 127.0.0.1:34634            127.0.0.1:8529
until 

{ [Error: connect EADDRNOTAVAIL]
  code: 'EADDRNOTAVAIL',
  errno: 'EADDRNOTAVAIL',
  syscall: 'connect' }

with:
watch -n 1 "ss -tan |grep 8529|wc -l"
Every 1.0s: ss -tan |grep 8529                                                                                                                             Tue Nov 18 21:54:07 2014

LISTEN     0      10                        *:8529                     *:*
ESTAB      0      0                 127.0.0.1:59175            127.0.0.1:8529
ESTAB      0      244               127.0.0.1:8529             127.0.0.1:59175
```

client:

``` javascript
  arango = require('arango');

  db = arango.Connection('http://127.0.0.1:8529');

  setTimeout(function() {
    var i, mach;
    i = 0;
    mach = function() {
      return db.document.get("test/" + (i++)).then(function(ret) {
        console.log(ret);
        return setImmediate(mach);
      }, function(ret) {
        console.log(ret);
        return setImmediate(mach);
      });
    };
    return mach();
  }, 1 * 1000);
```

related issues
https://github.com/joyent/node/issues/6833
https://github.com/triAGENS/ArangoDB/issues/985
